### PR TITLE
Addding a shortcode attribute and passing it to service.js

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -2,8 +2,8 @@ var services = angular.module('mixcloudServices',[]);
 
 // Service to interact with Mixcloud API and return the data
 services.service('mixcloudApi', function($http, $q){
-  // Two constants for the relevant API endpoints
-  const feedEndpoint = "https://api.mixcloud.com/smokeradio/cloudcasts/";
+  // Set constant for the relevant API endpoints from passed php variable
+  const feedEndpoint = phpVars.apiURL + "/";
   // LIST 20 RECENT PODCASTS, PAGE AS REQUESTED
   this.list = function(page){
     // Calculate the offset for the desired page

--- a/mixcloud-integrator.php
+++ b/mixcloud-integrator.php
@@ -8,7 +8,17 @@ Author URI: http://joshuahackett.com
 Version: 1.0.0
 */
 
-function show_mixcloud_integrator(){
+function show_mixcloud_integrator( $atts ){
+  // Make shortcode accept 'api_url' parameter
+  $atts = shortcode_atts( array(
+    'api_url' => '',
+  ), $atts, 'mixcloud-integrator' );
+
+  // Define variable to pass later to services.js
+  $passed_var = array(
+    'apiURL' => $atts['api_url'],
+  );
+
   // Get plugin CSS
   wp_enqueue_style('yuhh', plugin_dir_url( __FILE__ ) . '/css/style.css');
   // Get Angular lib
@@ -16,6 +26,8 @@ function show_mixcloud_integrator(){
   wp_enqueue_script('angular-animate', plugin_dir_url( __FILE__ ) . '/node_modules/angular-animate/angular-animate.js');
   // Get custom app scripts
   wp_enqueue_script('services', plugin_dir_url( __FILE__ ) . '/js/services.js');
+  // Pass the $passed_var to services.js
+  wp_localize_script( 'services', 'phpVars', $passed_var );
   wp_enqueue_script('app', plugin_dir_url( __FILE__ ) . '/js/app.js');
   // Lastly, include the markup template
   ob_start();


### PR DESCRIPTION
This allows users to define their own mixcloud API url instead of having to hardcoding it in service.js.
Either manually via shortcode parameter `[mixcloud-integrator api_url=SOMEMIXCLOUDAPIURL]`
or programmatically via do_shortcode() function in their template files.